### PR TITLE
fix(poc-sandbox): namespace segmentation

### DIFF
--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -111,20 +111,25 @@ const runPluginTagInSandbox = async (
   },
 ): Promise<string> => {
   const { runTagInSandbox } = await import('../templating/sandbox/plugin-tag-sandbox');
-  const { createMapBridge, scopePluginDataHandlers } = await import('../templating/sandbox/host-bridge');
+  const { createMapBridge, scopePluginDataHandlers, capUtilRenderDepth } = await import('../templating/sandbox/host-bridge');
   const { pluginName, tagName, args, context: originContext } = body;
   const { meta, renderPurpose, context } = originContext;
-  // Force the trusted pluginName onto pluginData.* calls so a tag can't forge another plugin's name.
+  // capUtilRenderDepth: bound nested util.render recursion (cheap guard layered on the sandbox's
+  //   interrupt/memory limits, which are the real DoS backstop).
+  // scopePluginDataHandlers: force the trusted pluginName onto pluginData.* calls so a tag can't
+  //   forge another plugin's name.
   const bridge = createMapBridge(
-    scopePluginDataHandlers(
-      {
-        ...(pluginToMainAPI as Record<string, (b: any) => Promise<any>>),
-        'util.render': async (b: { str: string; context: Record<string, any> }) => {
-          const { render } = await import('../templating');
-          return render(b.str, { context: b.context });
+    capUtilRenderDepth(
+      scopePluginDataHandlers(
+        {
+          ...(pluginToMainAPI as Record<string, (b: any) => Promise<any>>),
+          'util.render': async (b: { str: string; context: Record<string, any> }) => {
+            const { render } = await import('../templating');
+            return render(b.str, { context: b.context });
+          },
         },
-      },
-      pluginName,
+        pluginName,
+      ),
     ),
   );
   return runTagInSandbox({

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -111,16 +111,22 @@ const runPluginTagInSandbox = async (
   },
 ): Promise<string> => {
   const { runTagInSandbox } = await import('../templating/sandbox/plugin-tag-sandbox');
-  const { createMapBridge } = await import('../templating/sandbox/host-bridge');
+  const { createMapBridge, scopePluginDataHandlers } = await import('../templating/sandbox/host-bridge');
   const { pluginName, tagName, args, context: originContext } = body;
   const { meta, renderPurpose, context } = originContext;
-  const bridge = createMapBridge({
-    ...(pluginToMainAPI as Record<string, (b: any) => Promise<any>>),
-    'util.render': async (b: { str: string; context: Record<string, any> }) => {
-      const { render } = await import('../templating');
-      return render(b.str, { context: b.context });
-    },
-  });
+  // Force the trusted pluginName onto pluginData.* calls so a tag can't forge another plugin's name.
+  const bridge = createMapBridge(
+    scopePluginDataHandlers(
+      {
+        ...(pluginToMainAPI as Record<string, (b: any) => Promise<any>>),
+        'util.render': async (b: { str: string; context: Record<string, any> }) => {
+          const { render } = await import('../templating');
+          return render(b.str, { context: b.context });
+        },
+      },
+      pluginName,
+    ),
+  );
   return runTagInSandbox({
     pluginSource,
     tagName,

--- a/packages/insomnia/src/templating/sandbox/bridge-boundary-validation.test.ts
+++ b/packages/insomnia/src/templating/sandbox/bridge-boundary-validation.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { capUtilRenderDepth, createMapBridge } from './host-bridge';
+import { type ContextEnvelope, sanitizeErrorMessage } from './marshal';
+import { runTagInSandbox } from './plugin-tag-sandbox';
+
+const envelope = (args: unknown[], overrides: Partial<ContextEnvelope> = {}): ContextEnvelope => ({
+  args,
+  context: {},
+  meta: {},
+  renderPurpose: 'preview',
+  appInfo: { version: '0.0.0', platform: 'linux' },
+  pluginName: 'test-plugin',
+  renderDepth: 0,
+  ...overrides,
+});
+
+// ---- Fix 1: util.render depth cap (capUtilRenderDepth) ----
+describe('capUtilRenderDepth', () => {
+  it('delegates when depth is within the cap', async () => {
+    const render = vi.fn(async () => 'rendered');
+    const capped = capUtilRenderDepth({ 'util.render': render }, 3);
+    await expect(capped['util.render']({ str: 'x', depth: 3 })).resolves.toBe('rendered');
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it('rejects once depth exceeds the cap', async () => {
+    const render = vi.fn(async () => 'rendered');
+    const capped = capUtilRenderDepth({ 'util.render': render }, 3);
+    await expect(capped['util.render']({ str: 'x', depth: 4 })).rejects.toThrow(/maximum nesting depth of 3/);
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it('end-to-end: a tag whose util.render exceeds the cap fails', async () => {
+    const render = vi.fn(async () => 'rendered');
+    // maxDepth 2; the in-sandbox context sends depth = renderDepth + 1 = 6 → over the cap.
+    const bridge = createMapBridge(capUtilRenderDepth({ 'util.render': render }, 2));
+    const source = 'module.exports.templateTags = [{ name: "r", run: function (c) { return c.util.render("hi"); } }];';
+    await expect(
+      runTagInSandbox({ pluginSource: source, tagName: 'r', envelope: envelope([], { renderDepth: 5 }), bridge }),
+    ).rejects.toThrow(/maximum nesting depth of 2/);
+    expect(render).not.toHaveBeenCalled();
+  });
+});
+
+// ---- Fix 2: error-message sanitization ----
+describe('sanitizeErrorMessage', () => {
+  it('redacts POSIX absolute paths', () => {
+    expect(sanitizeErrorMessage("ENOENT: no such file, open '/Users/secret/.ssh/id_rsa'"))
+      .toBe("ENOENT: no such file, open '<redacted-path>'");
+  });
+
+  it('redacts Windows absolute paths', () => {
+    expect(sanitizeErrorMessage('cannot read C:\\Users\\secret\\notes.txt now'))
+      .toBe('cannot read <redacted-path> now');
+  });
+
+  it('leaves URLs and plain messages intact', () => {
+    expect(sanitizeErrorMessage('request to https://api.example.com/v1/users failed'))
+      .toBe('request to https://api.example.com/v1/users failed');
+    expect(sanitizeErrorMessage('bridge exploded')).toBe('bridge exploded');
+  });
+
+  it('end-to-end: a host error path does not leak into the sandbox', async () => {
+    const bridge = createMapBridge({
+      nodeOS: async () => {
+        throw new Error("ENOENT: open '/Users/victim/secrets.json'");
+      },
+    });
+    const source = 'module.exports.templateTags = [{ name: "o", run: async function (c) { return await c.util.nodeOS(); } }];';
+    await expect(
+      runTagInSandbox({ pluginSource: source, tagName: 'o', envelope: envelope([]), bridge }),
+    ).rejects.toThrow(/<redacted-path>/);
+  });
+});
+
+// ---- Fix 3: prototype-pollution guard at the JSON.parse boundary ----
+describe('prototype-pollution guard', () => {
+  it('strips __proto__ from the bridge body before it reaches a handler', async () => {
+    const received = vi.fn(async (_body: { request: Record<string, unknown> }) => null);
+    const bridge = createMapBridge({ 'network.sendRequest': received });
+    // JSON.parse inside the sandbox creates a real own "__proto__" key, which JSON.stringify then
+    // serialises into the bridge body — the exact shape the host reviver must neutralise.
+    const source = `module.exports.templateTags = [{
+      name: 'p',
+      run: function (c) {
+        var evil = JSON.parse('{"__proto__":{"polluted":"yes"},"url":"http://x"}');
+        return c.network.sendRequest(evil).then(function () { return 'ok'; });
+      }
+    }];`;
+    const out = await runTagInSandbox({ pluginSource: source, tagName: 'p', envelope: envelope([]), bridge });
+
+    expect(out).toBe('ok');
+    expect(received).toHaveBeenCalledOnce();
+    const body = received.mock.calls[0][0];
+    expect(body.request).toEqual({ url: 'http://x' });
+    // Neither the received object nor the host Object.prototype was polluted.
+    expect(Object.getPrototypeOf(body.request)).toBe(Object.prototype);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});
+
+// ---- Fix 4: payload size caps ----
+describe('payload size caps', () => {
+  it('rejects an oversized request payload', async () => {
+    const render = vi.fn(async () => 'rendered');
+    const bridge = createMapBridge({ 'util.render': render });
+    const source = `module.exports.templateTags = [{
+      name: 'big',
+      run: function (c) { var s = 'x'.repeat(499); return c.util.render(s); }
+    }];`;
+    await expect(
+      runTagInSandbox({ pluginSource: source, tagName: 'big', envelope: envelope([]), bridge, maxPayloadBytes: 50 }),
+    ).rejects.toThrow(/request payload too large/);
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it('rejects an oversized response payload', async () => {
+    const bridge = createMapBridge({ nodeOS: async () => ({ blob: 'y'.repeat(499) }) });
+    const source = 'module.exports.templateTags = [{ name: "o", run: async function (c) { return await c.util.nodeOS(); } }];';
+    await expect(
+      runTagInSandbox({ pluginSource: source, tagName: 'o', envelope: envelope([]), bridge, maxPayloadBytes: 50 }),
+    ).rejects.toThrow(/response payload too large/);
+  });
+});

--- a/packages/insomnia/src/templating/sandbox/host-bridge.ts
+++ b/packages/insomnia/src/templating/sandbox/host-bridge.ts
@@ -56,3 +56,32 @@ export const scopePluginDataHandlers = (
   }
   return scoped;
 };
+
+/** Upper bound on nested `context.util.render()` calls from inside the sandbox. */
+export const DEFAULT_MAX_RENDER_DEPTH = 8;
+
+/**
+ * Wrap the `util.render` handler to reject once the sandbox-reported nesting `depth` exceeds
+ * `maxDepth`. The in-sandbox context increments `depth` per nested `util.render`, so this is a cheap
+ * recursion guard layered on the runtime's interrupt + memory limits (the real DoS backstop). Note:
+ * `depth` resets across the unsandboxed in-process render engine, so this only bounds direct
+ * self-recursion within a single sandboxed invocation — full propagation is follow-up work.
+ */
+export const capUtilRenderDepth = (
+  handlers: Record<string, (body: any) => Promise<unknown>>,
+  maxDepth: number = DEFAULT_MAX_RENDER_DEPTH,
+): Record<string, (body: any) => Promise<unknown>> => {
+  const handler = handlers['util.render'];
+  if (!handler) {
+    return handlers;
+  }
+  return {
+    ...handlers,
+    'util.render': async body => {
+      if ((body?.depth ?? 0) > maxDepth) {
+        throw new Error(`util.render exceeded the maximum nesting depth of ${maxDepth}`);
+      }
+      return handler(body);
+    },
+  };
+};

--- a/packages/insomnia/src/templating/sandbox/host-bridge.ts
+++ b/packages/insomnia/src/templating/sandbox/host-bridge.ts
@@ -25,3 +25,34 @@ export const createMapBridge =
     }
     return handler(body);
   };
+
+/** Bridge paths whose storage is scoped per-plugin; their `pluginName` must come from the host. */
+export const PLUGIN_DATA_PATHS = [
+  'pluginData.hasItem',
+  'pluginData.setItem',
+  'pluginData.getItem',
+  'pluginData.removeItem',
+  'pluginData.clear',
+  'pluginData.all',
+] as const;
+
+/**
+ * Defense in depth for plugin storage. The in-sandbox context stamps the owning `pluginName` onto
+ * every `pluginData.*` call, but that value originates inside the sandbox and so can be forged. This
+ * wraps the `pluginData.*` handlers to overwrite `pluginName` with the trusted name the host knows
+ * for the executing tag, regardless of what the sandbox sent — preventing one plugin from reading or
+ * clearing another plugin's store. All other handlers pass through unchanged.
+ */
+export const scopePluginDataHandlers = (
+  handlers: Record<string, (body: any) => Promise<unknown>>,
+  pluginName: string,
+): Record<string, (body: any) => Promise<unknown>> => {
+  const scoped: Record<string, (body: any) => Promise<unknown>> = { ...handlers };
+  for (const path of PLUGIN_DATA_PATHS) {
+    const handler = handlers[path];
+    if (handler) {
+      scoped[path] = body => handler({ ...body, pluginName });
+    }
+  }
+  return scoped;
+};

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -16,6 +16,15 @@
 export const IN_SANDBOX_BOOTSTRAP = [
   '(function(){',
   '  "use strict";',
+
+  // --- capture the host-injected plumbing into closure locals, then delete the globals at the end ---
+  // so plugin code (evaluated after this bootstrap) can never reach the raw bridge / crypto / console
+  // host functions. The closures below keep these references alive; QuickJS retains the underlying
+  // host-function objects as long as a local still points at them.
+  '  var __hb = globalThis.__hostBridge;',
+  '  var __ch = globalThis.__cryptoHash, __chm = globalThis.__cryptoHmac, __crb = globalThis.__cryptoRandomBytes, __cru = globalThis.__cryptoRandomUUID;',
+  '  var __hc = globalThis.__hostConsole;',
+
   '  var T = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";',
 
   // --- btoa / atob (operate on Latin1 binary strings, matching the browser) ---
@@ -84,12 +93,12 @@ export const IN_SANDBOX_BOOTSTRAP = [
 
   // --- console (forwards to the host if a sink was injected) ---
   '  function __fmt(args) { var parts = []; for (var i = 0; i < args.length; i++) { var a = args[i]; try { parts.push(typeof a === "string" ? a : JSON.stringify(a)); } catch (e) { parts.push(String(a)); } } return parts.join(" "); }',
-  '  function __log(level) { return function () { if (typeof globalThis.__hostConsole === "function") { globalThis.__hostConsole(level, __fmt(arguments)); } }; }',
+  '  function __log(level) { return function () { if (typeof __hc === "function") { __hc(level, __fmt(arguments)); } }; }',
   '  globalThis.console = { log: __log("log"), info: __log("info"), warn: __log("warn"), error: __log("error"), debug: __log("debug") };',
 
   // --- the single async bridge helper ---
   '  function __bridge(path, body) {',
-  '    return globalThis.__hostBridge(path, JSON.stringify(body || {})).then(function (raw) {',
+  '    return __hb(path, JSON.stringify(body || {})).then(function (raw) {',
   '      var res = JSON.parse(raw);',
   '      if (!res.ok) { throw new Error(res.error && res.error.message ? res.error.message : "host bridge error: " + path); }',
   '      return res.value;',
@@ -120,7 +129,7 @@ export const IN_SANDBOX_BOOTSTRAP = [
   // crypto is backed by synchronous host functions (real host crypto), so digest()/randomBytes()
   // return values inline — matching node:crypto's synchronous contract.
   '    if (name === "crypto" || name === "node:crypto") {',
-  '      if (typeof globalThis.__cryptoHash !== "function") { throw new Error("\'crypto\' is not available in this sandbox"); }',
+  '      if (typeof __ch !== "function") { throw new Error("\'crypto\' is not available in this sandbox"); }',
   '      var mkDigester = function (compute) {',
   '        var parts = [];',
   '        var obj = {',
@@ -130,10 +139,10 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '        return obj;',
   '      };',
   '      return {',
-  '        createHash: function (algo) { return mkDigester(function (data, enc) { return globalThis.__cryptoHash(algo, data, "utf8", enc); }); },',
-  '        createHmac: function (algo, key) { var k = typeof key === "string" ? key : String(key); return mkDigester(function (data, enc) { return globalThis.__cryptoHmac(algo, k, data, enc); }); },',
+  '        createHash: function (algo) { return mkDigester(function (data, enc) { return __ch(algo, data, "utf8", enc); }); },',
+  '        createHmac: function (algo, key) { var k = typeof key === "string" ? key : String(key); return mkDigester(function (data, enc) { return __chm(algo, k, data, enc); }); },',
   '        randomBytes: function (size) {',
-  '          var b64 = globalThis.__cryptoRandomBytes(size);',
+  '          var b64 = __crb(size);',
   '          var binary = atob(b64);',
   '          return {',
   '            length: binary.length,',
@@ -144,7 +153,7 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '            }',
   '          };',
   '        },',
-  '        randomUUID: function () { return globalThis.__cryptoRandomUUID(); }',
+  '        randomUUID: function () { return __cru(); }',
   '      };',
   '    }',
   '    throw new Error("Cannot find module \'" + name + "\' in sandbox (not yet supported)");',
@@ -226,6 +235,12 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    var args = [ctx].concat(env.args || []);',
   '    return Promise.resolve(tag.run.apply(null, args)).then(function (r) { return r == null ? "" : String(r); });',
   '  };',
+
+  // --- remove the raw host capabilities from the global so plugin code can only reach the rebuilt
+  // context. The closures above retain the references they need (e.g. __bridge -> __hb). ---
+  '  delete globalThis.__hostBridge;',
+  '  delete globalThis.__cryptoHash; delete globalThis.__cryptoHmac; delete globalThis.__cryptoRandomBytes; delete globalThis.__cryptoRandomUUID;',
+  '  delete globalThis.__hostConsole;',
   '})();',
 ].join('\n');
 

--- a/packages/insomnia/src/templating/sandbox/marshal.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.ts
@@ -37,7 +37,20 @@ export interface BridgeResult {
 export const encodeBridgeSuccess = (value: unknown): string =>
   JSON.stringify({ ok: true, value: value ?? null } satisfies BridgeResult);
 
+/**
+ * Redact host filesystem paths from an error message before it crosses back into the sandbox. Host
+ * errors (e.g. a `readFile` ENOENT) embed absolute paths that disclose host layout; we strip those
+ * while keeping the rest of the message (error codes, network failures, validation text) intact so
+ * legitimate plugin error handling still works.
+ *  - Windows: `C:\Users\...`
+ *  - POSIX: `/Users/...` (≥2 segments), but not the path part of a `scheme://host/...` URL.
+ */
+const PATH_PATTERN = /[A-Za-z]:\\[^\s'"]+|(?<![:/\w])(?:\/[\w.\-@ ]+){2,}\/?/g;
+
+export const sanitizeErrorMessage = (message: string): string =>
+  message.replace(PATH_PATTERN, '<redacted-path>');
+
 export const encodeBridgeFailure = (err: unknown): string => {
-  const message = err instanceof Error ? err.message : String(err);
+  const message = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
   return JSON.stringify({ ok: false, error: { message } } satisfies BridgeResult);
 };

--- a/packages/insomnia/src/templating/sandbox/namespace-segmentation.test.ts
+++ b/packages/insomnia/src/templating/sandbox/namespace-segmentation.test.ts
@@ -1,0 +1,113 @@
+import nodeCrypto from 'node:crypto';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { createMapBridge, type HostBridge, scopePluginDataHandlers } from './host-bridge';
+import type { ContextEnvelope } from './marshal';
+import { type HostCrypto, runTagInSandbox } from './plugin-tag-sandbox';
+
+const nodeHostCrypto: HostCrypto = {
+  hash: (algo, data, inputEncoding, outputEncoding) =>
+    nodeCrypto.createHash(algo).update(data, inputEncoding as nodeCrypto.Encoding).digest(outputEncoding as nodeCrypto.BinaryToTextEncoding),
+  hmac: (algo, key, data, outputEncoding) =>
+    nodeCrypto.createHmac(algo, key).update(data, 'utf8').digest(outputEncoding as nodeCrypto.BinaryToTextEncoding),
+  randomBytes: size => nodeCrypto.randomBytes(size).toString('base64'),
+  randomUUID: () => nodeCrypto.randomUUID(),
+};
+
+const envelope = (args: unknown[], pluginName = 'attacker-plugin'): ContextEnvelope => ({
+  args,
+  context: {},
+  meta: {},
+  renderPurpose: 'preview',
+  appInfo: { version: '0.0.0', platform: 'linux' },
+  pluginName,
+  renderDepth: 0,
+});
+
+const noBridge: HostBridge = async path => {
+  throw new Error(`unexpected bridge call: ${path}`);
+};
+
+describe('sandbox namespace segmentation', () => {
+  // (A) Fix 1: the raw host bridge is no longer reachable from plugin code. __buildContext carries no
+  // capability (it only reshapes the envelope) so it may remain; __hostBridge must be gone.
+  it('(A) hides __hostBridge from plugin code', async () => {
+    const source = `module.exports.templateTags = [{
+      name: 'probe',
+      run: function () {
+        return 'hostBridge=' + (typeof globalThis.__hostBridge)
+          + ' cryptoHash=' + (typeof globalThis.__cryptoHash);
+      }
+    }];`;
+    const out = await runTagInSandbox({
+      pluginSource: source, tagName: 'probe', envelope: envelope([]), bridge: noBridge,
+    });
+    expect(out).toBe('hostBridge=undefined cryptoHash=undefined');
+  });
+
+  // (A') Fix 1: the raw crypto host functions are deleted from the global even when crypto is enabled,
+  // yet require('crypto') still works because the require shim closes over the captured references.
+  it("(A') deletes raw crypto globals but keeps require('crypto') working", async () => {
+    const source = `module.exports.templateTags = [{
+      name: 'probe',
+      run: function () {
+        var leaked = typeof globalThis.__cryptoHash;
+        var hash = require('crypto').createHash('sha256').update('hello world').digest('hex');
+        return leaked + ':' + hash;
+      }
+    }];`;
+    const out = await runTagInSandbox({
+      pluginSource: source, tagName: 'probe', envelope: envelope([]), bridge: noBridge, hostCrypto: nodeHostCrypto,
+    });
+    const expected = nodeCrypto.createHash('sha256').update('hello world', 'utf8').digest('hex');
+    expect(out).toBe(`undefined:${expected}`);
+  });
+
+  // (B) Fix 1: a tag trying to call the raw bridge directly fails — it's undefined, so the call throws.
+  it('(B) a direct __hostBridge call throws inside the tag', async () => {
+    const source = `module.exports.templateTags = [{
+      name: 'steal',
+      run: function () {
+        return globalThis.__hostBridge('pluginData.getItem', JSON.stringify({ pluginName: 'victim-plugin', key: 'secret' }));
+      }
+    }];`;
+    await expect(
+      runTagInSandbox({ pluginSource: source, tagName: 'steal', envelope: envelope([]), bridge: noBridge }),
+    ).rejects.toThrow();
+  });
+
+  // (C) Fix 2: host-side scoping forces the trusted pluginName onto pluginData.* calls, end-to-end
+  // through the legitimate context.store path.
+  it('(C) forces the trusted pluginName on store calls', async () => {
+    const handler = vi.fn(async (body: { pluginName: string; key: string }) => `value:${body.pluginName}`);
+    const bridge = createMapBridge(
+      scopePluginDataHandlers({ 'pluginData.getItem': handler }, 'attacker-plugin'),
+    );
+    const source = `module.exports.templateTags = [{
+      name: 'read',
+      run: function (context) { return context.store.getItem('secret'); }
+    }];`;
+    const out = await runTagInSandbox({
+      pluginSource: source, tagName: 'read', envelope: envelope([], 'attacker-plugin'), bridge,
+    });
+    expect(handler).toHaveBeenCalledWith({ pluginName: 'attacker-plugin', key: 'secret' });
+    expect(out).toBe('value:attacker-plugin');
+  });
+
+  // (C') Fix 2 unit: even a forged pluginName in the body is overridden with the trusted one.
+  it("(C') scopePluginDataHandlers overrides a forged pluginName", async () => {
+    const handler = vi.fn(async (body: { pluginName: string; key: string }) => body.pluginName);
+    const scoped = scopePluginDataHandlers({ 'pluginData.getItem': handler }, 'attacker-plugin');
+    await scoped['pluginData.getItem']({ pluginName: 'victim-plugin', key: 'secret' });
+    expect(handler).toHaveBeenCalledWith({ pluginName: 'attacker-plugin', key: 'secret' });
+  });
+
+  // (D) Fix 3: a synchronous infinite loop is interrupted within the deadline instead of hanging.
+  it('(D) interrupts a synchronous infinite loop', async () => {
+    const source = 'module.exports.templateTags = [{ name: "spin", run: function () { while (true) {} } }];';
+    await expect(
+      runTagInSandbox({ pluginSource: source, tagName: 'spin', envelope: envelope([]), bridge: noBridge, timeoutMs: 200 }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -34,6 +34,8 @@ export interface RunTagInSandboxOptions {
   timeoutMs?: number;
   /** Hard memory cap for the QuickJS runtime. Defaults to 64 MiB. */
   memoryLimitBytes?: number;
+  /** Max size of a single marshaled bridge payload (request or response). Defaults to 8 MiB. */
+  maxPayloadBytes?: number;
 }
 
 /**
@@ -42,7 +44,10 @@ export interface RunTagInSandboxOptions {
  * intermediate handles are reclaimed wholesale.
  */
 export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<string> => {
-  const { pluginSource, tagName, envelope, bridge, onConsole, timeoutMs = 10_000, memoryLimitBytes = 64 * 1024 * 1024 } = opts;
+  const {
+    pluginSource, tagName, envelope, bridge, onConsole,
+    timeoutMs = 10_000, memoryLimitBytes = 64 * 1024 * 1024, maxPayloadBytes = MAX_BRIDGE_PAYLOAD_BYTES,
+  } = opts;
   const { getQuickJSModule } = await import('./quickjs-runtime');
   const QuickJS = await getQuickJSModule();
   const ctx = QuickJS.newContext();
@@ -53,7 +58,7 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
     ctx.runtime.setInterruptHandler(shouldInterruptAfterDeadline(Date.now() + timeoutMs));
     ctx.runtime.setMemoryLimit(memoryLimitBytes);
 
-    installHostBridge(ctx, bridge);
+    installHostBridge(ctx, bridge, maxPayloadBytes);
     installHostConsole(ctx, onConsole);
     installHostCrypto(ctx, opts.hostCrypto);
 
@@ -69,21 +74,48 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
   }
 };
 
+/** Max size of a single marshaled bridge payload (request body or handler result JSON). */
+const MAX_BRIDGE_PAYLOAD_BYTES = 8 * 1024 * 1024;
+
+/** Keys that enable prototype pollution; dropped from any object parsed out of the sandbox. */
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * JSON.parse reviver that strips prototype-pollution keys. The body is fully attacker-controlled and
+ * is handed to host handlers (e.g. network.sendRequest, cloudCredential.update) that may spread or
+ * deep-merge it, so a `__proto__` key must never survive the parse.
+ */
+const stripDangerousKeys = (key: string, value: unknown): unknown => (DANGEROUS_KEYS.has(key) ? undefined : value);
+
 /** Register `__hostBridge(path, bodyJson)` returning a VM promise resolved from async host work. */
-const installHostBridge = (ctx: QuickJSContext, bridge: HostBridge): void => {
+const installHostBridge = (ctx: QuickJSContext, bridge: HostBridge, maxPayloadBytes: number): void => {
   const fn = ctx.newFunction('__hostBridge', (pathHandle, bodyHandle) => {
     const path = ctx.getString(pathHandle);
+    const bodyJson = ctx.getString(bodyHandle);
+    const deferred = ctx.newPromise();
+
+    if (bodyJson.length > maxPayloadBytes) {
+      resolveWithString(ctx, deferred, encodeBridgeFailure(new Error('bridge request payload too large')));
+      deferred.settled.then(() => ctx.runtime.executePendingJobs());
+      return deferred.handle;
+    }
+
     let body: unknown;
     try {
-      body = JSON.parse(ctx.getString(bodyHandle));
+      body = JSON.parse(bodyJson, stripDangerousKeys);
     } catch {
       body = {};
     }
-    const deferred = ctx.newPromise();
     Promise.resolve()
       .then(() => bridge(path, body))
+      .then(value => {
+        const encoded = encodeBridgeSuccess(value);
+        return encoded.length > maxPayloadBytes
+          ? encodeBridgeFailure(new Error('bridge response payload too large'))
+          : encoded;
+      })
       .then(
-        value => resolveWithString(ctx, deferred, encodeBridgeSuccess(value)),
+        json => resolveWithString(ctx, deferred, json),
         err => resolveWithString(ctx, deferred, encodeBridgeFailure(err)),
       );
     // The settled VM promise schedules a job; pump it so the awaiting sandbox code resumes.

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -1,4 +1,4 @@
-import type { QuickJSContext, QuickJSHandle } from 'quickjs-emscripten';
+import { type QuickJSContext, type QuickJSHandle, shouldInterruptAfterDeadline } from 'quickjs-emscripten';
 
 import type { HostBridge } from './host-bridge';
 import { IN_SANDBOX_BOOTSTRAP, RUNNER, wrapPluginSource } from './in-sandbox-bootstrap';
@@ -32,6 +32,8 @@ export interface RunTagInSandboxOptions {
   onConsole?: (level: string, message: string) => void;
   /** Wall-clock cap for the whole tag run; mirrors the LiquidJS renderLimit (10s). */
   timeoutMs?: number;
+  /** Hard memory cap for the QuickJS runtime. Defaults to 64 MiB. */
+  memoryLimitBytes?: number;
 }
 
 /**
@@ -40,12 +42,17 @@ export interface RunTagInSandboxOptions {
  * intermediate handles are reclaimed wholesale.
  */
 export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<string> => {
-  const { pluginSource, tagName, envelope, bridge, onConsole, timeoutMs = 10_000 } = opts;
+  const { pluginSource, tagName, envelope, bridge, onConsole, timeoutMs = 10_000, memoryLimitBytes = 64 * 1024 * 1024 } = opts;
   const { getQuickJSModule } = await import('./quickjs-runtime');
   const QuickJS = await getQuickJSModule();
   const ctx = QuickJS.newContext();
 
   try {
+    // CPU + memory guards. The interrupt handler is polled regularly by the interpreter, so it stops
+    // synchronous infinite loops that drivePromiseToString's between-yields deadline cannot catch.
+    ctx.runtime.setInterruptHandler(shouldInterruptAfterDeadline(Date.now() + timeoutMs));
+    ctx.runtime.setMemoryLimit(memoryLimitBytes);
+
     installHostBridge(ctx, bridge);
     installHostConsole(ctx, onConsole);
     installHostCrypto(ctx, opts.hostCrypto);


### PR DESCRIPTION
## What & Why
Builds on #10095, which runs plugin template tags in a QuickJS-WASM sandbox. That PoC
isolates code execution, but a security pass found two gaps: the host bridge still passed
untrusted data through unchecked, and the sandbox's raw host functions stayed reachable on the
global scope. There were also no CPU or memory limits, so a tag could hang the process. This PR
closes those gaps so the sandbox is an actual trust boundary.

## Approach
- **Namespace segmentation**: the host-injected `__hostBridge` / `__crypto*` / `__hostConsole`
  globals are captured into closure locals and deleted from `globalThis` at the end of the
  bootstrap, before plugin source evaluates. The closures keep the references they need, so plugin
  code can only reach the rebuilt `context`, never the raw bridge.
- **Host-side plugin identity**: `scopePluginDataHandlers` forces the trusted `pluginName` onto
  every `pluginData.*` call, so a tag can't forge another plugin's name to read or clear its store.
  Identity comes from the host, never from the sandbox body.
- **DoS guards**: install a QuickJS interrupt handler (`shouldInterruptAfterDeadline`) plus a memory
  limit, so a synchronous `while(true){}` is interrupted within the deadline instead of hanging the
  process. The async driver deadline alone can't catch synchronous loops.
- **Bridge boundary hardening**: `util.render` depth cap (`capUtilRenderDepth`); host error-message
  path redaction (`sanitizeErrorMessage`); prototype-pollution stripping
  (`__proto__`/`constructor`/`prototype`) on the parsed bridge body; request and response payload
  size caps (`maxPayloadBytes`, default 8 MiB).

## Scope
- Same scope as #10095: template tags only; sandbox runs in **main**; renderer→worker→IPC path
  unchanged — **only main-side execute handlers and the sandbox internals change**.
- `templateTagSandboxEnabled` stays default-off; legacy path untouched when off.
- `require` shim still `path` + `crypto` only.

## Files
- `src/templating/sandbox/in-sandbox-bootstrap.ts` — capture + delete raw host globals
- `src/templating/sandbox/host-bridge.ts` — `scopePluginDataHandlers`, `capUtilRenderDepth`
- `src/templating/sandbox/plugin-tag-sandbox.ts` — interrupt + memory guards, prototype-pollution
  reviver, payload caps (`maxPayloadBytes` option)
- `src/templating/sandbox/marshal.ts` — `sanitizeErrorMessage` in `encodeBridgeFailure`
- `src/main/templating-worker-database.ts` — compose `capUtilRenderDepth(scopePluginDataHandlers(...))`
- `src/templating/sandbox/{namespace-segmentation,bridge-hardening}.test.ts` — new tests

## Tests / verification
- `namespace-segmentation.test.ts` (6): `__hostBridge` hidden; crypto globals deleted but
  `require('crypto')` still works; direct bridge call throws; cross-plugin forge overridden;
  synchronous infinite loop interrupted.
- `bridge-hardening.test.ts` (10): depth-cap unit + end-to-end; path redaction (POSIX/Windows/URL);
  `__proto__` stripped without polluting `Object.prototype`; oversized request/response rejected.
- Full sandbox suite **37 pass** (21 parity unchanged + 6 + 10); ESLint + `tsc` clean on touched files.

## Known limitations / follow-ups
- **Coverage boundary**: only the worker→IPC execute handlers are gated; the in-process `render()`
  engine (`createLiquidTag`) and nested `util.render` still run unsandboxed. The depth cap bounds
  direct self-recursion but `depth` resets across the ungated engine.
- WASM/dependency supply chain not yet pinned.
- `require` allowlist still breaks plugins using `fs`/`lodash`/`axios` (inherited from #10095).